### PR TITLE
feat(upvotes): add endpoints to create and delete upvotes with duplicate prevention

### DIFF
--- a/Models/DTO/CreateUpVoteDTO.cs
+++ b/Models/DTO/CreateUpVoteDTO.cs
@@ -1,0 +1,5 @@
+public class CreateUpVoteDTO
+{
+    public int UserId { get; set; }
+    public int RecommendationId { get; set; }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -295,5 +295,41 @@ app.MapGet("/api/cities/{cityId}/users", (TravelLoggerDbContext db, int cityId) 
     return result;
 });
 
+// ! Upvote Endpoints
+
+// POST /api/upvotes - Add an upvote
+app.MapPost("/api/upvotes", (TravelLoggerDbContext db, CreateUpVoteDTO dto) =>
+{
+    bool exists = db.UpVote.Any(u =>
+        u.UserId == dto.UserId && u.RecommendationId == dto.RecommendationId);
+
+    if (exists)
+    {
+        return Results.Conflict("User has already upvoted.");
+    }
+
+    var upvote = new UpVote { UserId = dto.UserId, RecommendationId = dto.RecommendationId };
+    db.UpVote.Add(upvote);
+    db.SaveChanges();
+
+    return Results.Created($"/api/upvotes/{upvote.Id}", upvote);
+});
+
+
+// DELETE /api/upvotes/{id} - Remove an upvote
+app.MapDelete("/api/upvotes/{id}", (TravelLoggerDbContext db, int id) =>
+{
+    var upvote = db.UpVote.FirstOrDefault(u => u.Id == id);
+    if (upvote == null)
+    {
+        return Results.NotFound();
+    }
+
+    db.UpVote.Remove(upvote);
+    db.SaveChanges();
+    return Results.Ok();
+});
+
+
 
 app.Run();


### PR DESCRIPTION
## Title: Add endpoints for creating and deleting upvotes


### What this does

- Adds POST /api/upvotes to create an upvote for a recommendation
- Adds DELETE /api/upvotes/{id} to remove an upvote by ID
- Prevents duplicate upvotes (same user on same recommendation)
- Introduces CreateUpVoteDTO to simplify input handling

### Why

Allows users to upvote and un-upvote recommendations.
Prevents duplicate entries and improves API clarity.

